### PR TITLE
solves performance issue when there are dozens of series in the chart

### DIFF
--- a/reverseLegendClickAction.js
+++ b/reverseLegendClickAction.js
@@ -30,7 +30,7 @@
                 if(legendClickedChart.options.chart.__visibleSeries.length == 1 && legendClickedChart.options.chart.__visibleSeries[0] === this.name){
                   // make all legend items visible
                   legendClickedChart.series.forEach(function (serie) {
-                    serie.setVisible(true);
+                    serie.setVisible(true, false);
                   });
                   legendClickedChart.options.chart.__visibleSeries.length = 0;
                   return false;
@@ -38,7 +38,7 @@
                 if(!legendClickedChart.options.chart.__visibleSeries.includes(this.name)){
                   legendClickedChart.options.chart.__visibleSeries.push(this.name);
                 }else{
-                  this.setVisible(false);
+                  this.setVisible(false, false);
                   index = legendClickedChart.options.chart.__visibleSeries.indexOf(this.name);
                   legendClickedChart.options.chart.__visibleSeries.splice(index, 1);
                   return false;
@@ -48,9 +48,9 @@
                 legendClickedChart.series.forEach(function (serie) {
                   if(!serie.name.includes('Navigator')){
                     if(legendClickedChart.options.chart.__visibleSeries.includes(serie.name)){
-                      serie.setVisible(true);
+                      serie.setVisible(true, false);
                     }else{
-                      serie.setVisible(false);
+                      serie.setVisible(false, false);
                     }
                   }
                 });
@@ -61,6 +61,7 @@
                 if(legendClickedChart.options.chart.__visibleSeries.length === totalSeriesLength){
                   legendClickedChart.options.chart.__visibleSeries.length = 0;
                 }
+                this.redraw();
               }
             }
           }


### PR DESCRIPTION
When there are dozens of series on a chart, there is a severe performance hit because the chart tries to redraw everytime `series.setVisible()` is called.  

Per the highcharts documentation https://api.highcharts.com/class-reference/Highcharts.Series#setVisible
> If doing more operations on the chart, it is a good idea to set redraw to false and call chart.redraw() after.

This fix disables redraw when `setVisible()` is called, and does a single final redraw after all series have been updated.



